### PR TITLE
#18 Possibility to filter the fonts

### DIFF
--- a/projects/app/src/app/app.component.css
+++ b/projects/app/src/app/app.component.css
@@ -9,7 +9,7 @@
 .box-container {
   box-sizing: border-box;
   width: 800px;
-  height: 500px;
+  height: 535px;
   max-width: 90%;
   max-height: 90%;
   padding: 24px;

--- a/projects/app/src/app/app.component.html
+++ b/projects/app/src/app/app.component.html
@@ -10,13 +10,17 @@
       <div class="box-title">Settings</div>
 
       <div class="action-container" fxLayout="column" fxLayoutAlign="stretch" fxFlex>
-        <div class="action-button" fxLayout="column" fxLayoutAlign="center center" fxFlex [(fontPicker)]="font" [fpWidth]="'auto'" [fpPosition]="'bottom'" [fpPositionOffset]="'0%'" [fpPositionRelativeToArrow]="false" [fpPresetLabel]="'Preset fonts'" [fpPresetFonts]="presetFonts" [fpSizeSelect]="sizeSelect" [fpStyleSelect]="styleSelect">
+        <div class="action-button" fxLayout="column" fxLayoutAlign="center center" fxFlex [(fontPicker)]="font" [fpWidth]="'auto'" [fpPosition]="'bottom'" [fpPositionOffset]="'0%'" [fpPositionRelativeToArrow]="false" [fpPresetLabel]="'Preset fonts'" [fpPresetFonts]="presetFonts" [fpSizeSelect]="sizeSelect" [fpStyleSelect]="styleSelect" [fpPopularLabel]="" [fpFilterByFamilies]="filteredFonts" [fpSortByFamilies]="sortFonts">
           {{font?.family}} {{font?.style | FontStyles}} {{font?.size}}
         </div>
 
         <div class="action-button" fxLayout="column" fxLayoutAlign="center center" fxFlex (click)="togglePresetFonts()">Preset fonts: {{presetFonts.length ? "ON" : "OFF"}}</div>
 
         <div class="action-button" fxLayout="column" fxLayoutAlign="center center" fxFlex (click)="toggleExtraOptions()">Style & size: {{(sizeSelect || styleSelect) ? "ON" : "OFF"}}</div>
+
+        <div class="action-button" fxLayout="column" fxLayoutAlign="center center" fxFlex (click)="toggleFilterFonts()">Filter fonts: {{filteredFonts.length ? "ON" : "OFF"}}</div>
+
+        <div class="action-button" fxLayout="column" fxLayoutAlign="center center" fxFlex (click)="toggleSortOptions()">Sort by name: {{sortFonts ? "ON" : "OFF"}}</div>
       </div>
     </div>
 

--- a/projects/app/src/app/app.component.ts
+++ b/projects/app/src/app/app.component.ts
@@ -9,6 +9,7 @@ import { Font } from 'ngx-font-picker';
   styleUrls: [ 'app.component.css' ]
 })
 export class AppComponent {
+  private _filteredFonts = ['Open Sans', 'Oswald', 'Courier', 'Nunito Sans', 'Quicksand', 'Karla', 'Oxygen', 'Dosis', 'Bitter', 'Noto Sans SC', 'Assistant', 'Domine'];
   private _presetFonts = ['Arial', 'Times', 'Courier', 'Lato', 'Open Sans', 'Roboto Slab'];
 
   public font: Font = new Font({
@@ -19,8 +20,10 @@ export class AppComponent {
   });
 
   public sizeSelect: boolean = true;
+  public sortFonts: boolean = false;
   public styleSelect: boolean = true;
 
+  public filteredFonts = [];
   public presetFonts = this._presetFonts;
 
   constructor() {}
@@ -32,5 +35,13 @@ export class AppComponent {
   public toggleExtraOptions(): void {
     this.sizeSelect = !this.sizeSelect;
     this.styleSelect = !this.styleSelect;
+  }
+
+  public toggleFilterFonts(): void {
+    this.filteredFonts = this.filteredFonts.length ? [] : this._filteredFonts;
+  }
+
+  public toggleSortOptions(): void {
+    this.sortFonts = !this.sortFonts;
   }
 }

--- a/projects/lib/README.md
+++ b/projects/lib/README.md
@@ -109,6 +109,9 @@ const DEFAULT_FONT_PICKER_CONFIG: FontPickerConfigInterface = {
 [fpUseRootViewContainer]     // Create dialog component in the root view container (false).
                              // Note: The root component needs to have public viewContainerRef.
 
+[fpFilterByFamilies]         // Provides a list of font families that are allowed to be used (Default: [])
+[fpSortByFamilies]           // Sort fonts by family (Default: false)
+
 (fontPickerChange)           // Event handler for the font / size / style change.
 
 (fontPickerUpload)           // Event handler for the font upload button click event.

--- a/projects/lib/src/lib/font-picker.component.html
+++ b/projects/lib/src/lib/font-picker.component.html
@@ -30,7 +30,7 @@
     </div>
 
     <ng-container *ngIf="googleFonts.length">
-      <div class="font-group">
+      <div class="font-group" *ngIf="!fpFilterByFamilies.length || fpPresetFonts.length">
         <div class="group-text black">{{listLabel || ''}}</div>
         <div class="group-line black"></div>
       </div>

--- a/projects/lib/src/lib/font-picker.component.ts
+++ b/projects/lib/src/lib/font-picker.component.ts
@@ -94,6 +94,9 @@ export class FontPickerComponent implements OnInit {
 
   public fpDialogDisplay: string;
 
+  public fpFilterByFamilies: string[] = [];
+  public fpSortByFamilies = false;
+
   public dialogArrowSize: number = 10;
   public dialogArrowOffset: number = 15;
 
@@ -175,7 +178,8 @@ export class FontPickerComponent implements OnInit {
     fpSearchText: string, fpLoadingText: string, fpPopularLabel: string, fpResultsLabel: string,
     fpPresetLabel: string, fpPresetFonts: string[], fpPresetNotice: string,
     fpCancelButton: boolean, fpCancelButtonText: string, fpCancelButtonClass: string,
-    fpUploadButton: boolean, fpUploadButtonText: string, fpUploadButtonClass: string): void
+    fpUploadButton: boolean, fpUploadButtonText: string, fpUploadButtonClass: string,
+    fpFilterByFamilies: string[], fpSortByFamilies: boolean): void
   {
     this.listLabel = fpLoadingText;
 
@@ -187,7 +191,8 @@ export class FontPickerComponent implements OnInit {
     this.updateDialog(defaultFont, fpWidth, fpHeight, fpDialogDisplay, fpSizeSelect, fpStyleSelect,
       fpPosition, fpPositionOffset, fpPositionRelativeToArrow, fpSearchText, fpLoadingText,
       fpPopularLabel, fpResultsLabel, fpPresetLabel, fpPresetFonts, fpPresetNotice, fpCancelButton,
-      fpCancelButtonText, fpCancelButtonClass, fpUploadButton, fpUploadButtonText, fpUploadButtonClass);
+      fpCancelButtonText, fpCancelButtonClass, fpUploadButton, fpUploadButtonText, fpUploadButtonClass,
+      fpFilterByFamilies, fpSortByFamilies);
 
     this.service.getAllFonts('popularity').subscribe((fonts: GoogleFontsInterface) => {
       this.loading = false;
@@ -201,6 +206,17 @@ export class FontPickerComponent implements OnInit {
               styles: font.variants
             });
           });
+        }
+
+        if (fpFilterByFamilies?.length) {
+          this.googleFonts = this.googleFonts.filter((font: Font) =>
+            fpFilterByFamilies.includes(font.family)
+          );
+        }
+        if (fpSortByFamilies) {
+          this.googleFonts = this.googleFonts.sort((a, b) =>
+            a.family < b.family ? -1 : 1
+          );
         }
 
         // Find styles for initial font
@@ -234,7 +250,8 @@ export class FontPickerComponent implements OnInit {
     fpSearchText: string, fpLoadingText: string, fpPopularLabel: string, fpResultsLabel: string,
     fpPresetLabel: string, fpPresetFonts: string[], fpPresetNotice: string,
     fpCancelButton: boolean, fpCancelButtonText: string, fpCancelButtonClass: string,
-    fpUploadButton: boolean, fpUploadButtonText: string, fpUploadButtonClass: string): void
+    fpUploadButton: boolean, fpUploadButtonText: string, fpUploadButtonClass: string,
+    fpFilterByFamilies: string[], fpSortByFamilies: boolean): void
   {
     this.selectedFont = !!font;
 
@@ -273,6 +290,9 @@ export class FontPickerComponent implements OnInit {
     this.fpUploadButton = fpUploadButton;
     this.fpUploadButtonText = fpUploadButtonText;
     this.fpUploadButtonClass = fpUploadButtonClass;
+
+    this.fpFilterByFamilies = fpFilterByFamilies;
+    this.fpSortByFamilies = fpSortByFamilies;
 
     this.autoWidth = fpWidth === 'auto';
 

--- a/projects/lib/src/lib/font-picker.directive.ts
+++ b/projects/lib/src/lib/font-picker.directive.ts
@@ -57,6 +57,9 @@ export class FontPickerDirective implements OnInit, OnChanges {
   @Input('fpUploadButtonText') fpUploadButtonText: string = 'Upload';
   @Input('fpUploadButtonClass') fpUploadButtonClass: string = 'fp-upload-button-class';
 
+  @Input("fpFilterByFamilies") fpFilterByFamilies: string[] = [];
+  @Input("fpSortByFamilies") fpSortByFamilies = false;
+
   @Output('fontPickerUpload') fontPickerUpload = new EventEmitter<void>();
   @Output('fontPickerChange') fontPickerChange = new EventEmitter<FontInterface>();
 
@@ -79,6 +82,9 @@ export class FontPickerDirective implements OnInit, OnChanges {
       if (this.fpAutoLoad) {
         this.loadFont(this.fontPicker);
       }
+    }
+    if (changes.fpSortByFamilies || changes.fpFilterByFamilies) {
+      this.dialog = undefined;
     }
   }
 
@@ -131,7 +137,8 @@ export class FontPickerDirective implements OnInit, OnChanges {
         this.fpSearchText, this.fpLoadingText, this.fpPopularLabel, this.fpResultsLabel,
         this.fpPresetLabel, this.fpPresetFonts, this.fpPresetNotice,
         this.fpCancelButton, this.fpCancelButtonText, this.fpCancelButtonClass,
-        this.fpUploadButton, this.fpUploadButtonText, this.fpUploadButtonClass);
+        this.fpUploadButton, this.fpUploadButtonText, this.fpUploadButtonClass,
+        this.fpFilterByFamilies, this.fpSortByFamilies);
     } else if (!this.dialog.open) {
       this.dialog.updateDialog(this.fontPicker, this.fpWidth, this.fpHeight,
         this.fpDialogDisplay, this.fpSizeSelect, this.fpStyleSelect,
@@ -139,7 +146,8 @@ export class FontPickerDirective implements OnInit, OnChanges {
         this.fpSearchText, this.fpLoadingText, this.fpPopularLabel, this.fpResultsLabel,
         this.fpPresetLabel, this.fpPresetFonts, this.fpPresetNotice,
         this.fpCancelButton, this.fpCancelButtonText, this.fpCancelButtonClass,
-        this.fpUploadButton, this.fpUploadButtonText, this.fpUploadButtonClass);
+        this.fpUploadButton, this.fpUploadButtonText, this.fpUploadButtonClass,
+        this.fpFilterByFamilies, this.fpSortByFamilies);
 
       this.dialog.openFontPicker();
     } else {


### PR DESCRIPTION
Addressing https://github.com/zefoy/ngx-font-picker/issues/18, I added the possibility to filter fonts and to sort by font name.

Use case: If you are using this component to choose fonts for a document that is rendered server-side (e.g. a PDF), then you may not want to give users all Google Fonts up for selection, but only a subset of fonts for which you have a server-side rendering licence and/or which are installed on your server.